### PR TITLE
Update field

### DIFF
--- a/xp001/project/core/models.py
+++ b/xp001/project/core/models.py
@@ -28,9 +28,6 @@ class Cnpj(Identification):
 class IdentificationField(models.Field):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-
-        self.name = kwargs.get("name")
-
         self.field_value = models.CharField(max_length=256)
         self.field_type = models.CharField(max_length=32, choices=IdentificationTypes.choices)
 

--- a/xp001/project/core/models.py
+++ b/xp001/project/core/models.py
@@ -13,26 +13,34 @@ class BadCustomer(models.Model):
 
 
 class Identification(str):
-    pass
-
+    def from_type(type, value):
+        if (type == "BrCpf"):
+            return Cpf()
+        if (type == "BrCnpj"):
+            return Cnpj()
 
 class Cpf(Identification):
     pass
 
+class Cnpj(Identification):
+    pass
 
 class IdentificationField(models.Field):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+        self.name = kwargs.get("name")
+
         self.field_value = models.CharField(max_length=256)
         self.field_type = models.CharField(max_length=32, choices=IdentificationTypes.choices)
 
-        self.field_value_name = f"{self.name}_value"
-        self.field_type_name = f"{self.name}_type"
-
-    def contribute_to_class(self, cls, name, private_only=False):
+    def contribute_to_class(self, cls, name, private_only=True):
+        self.field_type_name = f"{name}_type"
+        self.field_value_name = f"{name}_value"
         cls.add_to_class(self.field_type_name, self.field_type)
         cls.add_to_class(self.field_value_name, self.field_value)
+        super().contribute_to_class(cls, name, private_only)
+
 
     def __set__(self, instance, value):
         if not isinstance(value, Identification):

--- a/xp001/project/core/tests/test_core.py
+++ b/xp001/project/core/tests/test_core.py
@@ -1,5 +1,5 @@
 import pytest
-from project.core.models import GoodCustomer, BadCustomer, IdentificationTypes, Cpf, Identification
+from project.core.models import GoodCustomer, BadCustomer, IdentificationTypes, Cpf, Identification, Cnpj
 
 
 @pytest.mark.django_db
@@ -22,7 +22,11 @@ class TestCustomerModel:
         assert type(c.identification) == Cpf
         assert c.identification == "11144477735"
 
-    # def test_factory(self):
-    #     ident = Identification.from_type("BrCpf", "11144477735")
-    #     assert type(ident) == Cpf
-    #     assert issubclass(Cpf, Identification)
+    def test_factory(self):
+        ident = Identification.from_type("BrCpf", "11144477735")
+        assert type(ident) == Cpf
+        assert issubclass(Cpf, Identification)
+
+        ident_cnpj = Identification.from_type("BrCnpj", "11144477735")
+        assert type(ident_cnpj) == Cnpj
+        assert issubclass(Cnpj, Identification)


### PR DESCRIPTION
Não tenho muita certeza do que houve mas segue o raciocínio:

Os testes estavam indicando erro na query ('identification', 'None_type', 'None_value') então suspeitei que `self.name` não estava definido no momento do init. Sendo assim, movi a definição das propriedades `self.field_value_name` e `self.field_type_name` para o método `contribute_to_class` (acredito que não seja o ideal mas foi o que consegui). 

Os testes continuaram falhando, então adicionei à chamada `super().contribute_to_class` (vi em algumas implementações de Custom Field que utilizam dessa forma). Os testes passaram, pelo que entendi `identification` está sendo considerada adicionada uma coluna no banco de dados.